### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/wallstorie/server/package.json
+++ b/wallstorie/server/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.11.0",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9",
-    "razorpay": "^2.9.6"
+    "razorpay": "^2.9.6",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/wallstorie/server/routes/admin/product-routes.js
+++ b/wallstorie/server/routes/admin/product-routes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const RateLimit = require("express-rate-limit");
 
 const {
   handleImageUpload,
@@ -11,10 +12,16 @@ const {
 const { upload } = require("../../helpers/cloudinary");
 
 const router = express.Router();
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 router.post("/upload-image", upload.single("file"), handleImageUpload);
 router.post("/add", addProduct);
 router.put("/edit/:id", editProduct);
 router.delete("/delete/:id", deleteProduct);
-router.get("/get", fetchAllProducts);
+router.get("/get", limiter, fetchAllProducts);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/14](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/14)

To fix the problem, we need to introduce rate limiting to the `fetchAllProducts` route to prevent potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` middleware. This middleware allows us to set a maximum number of requests that can be made to the route within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the `fetchAllProducts` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
