### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/wallstorie/server/package.json
+++ b/wallstorie/server/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.11.0",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9",
-    "razorpay": "^2.9.6"
+    "razorpay": "^2.9.6",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/wallstorie/server/routes/shop/addressroutes.js
+++ b/wallstorie/server/routes/shop/addressroutes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 
 const {
   addAddress,
@@ -9,8 +10,13 @@ const {
 
 const router = express.Router();
 
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 router.post("/add", addAddress);
-router.get("/get/:userId", fetchAllAddress);
+router.get("/get/:userId", limiter, fetchAllAddress);
 router.delete("/delete/:userId/:addressId", deleteAddress);
 router.put("/update/:userId/:addressId", editAddress);
 


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/6](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/6)

To fix the problem, we need to introduce rate limiting to the Express application to prevent potential denial-of-service attacks. The best way to do this is by using the `express-rate-limit` package, which allows us to set up a rate limiter and apply it to the routes that perform expensive operations.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the route that performs the database access (`fetchAllAddress`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
