### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/wallstorie/server/package.json
+++ b/wallstorie/server/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.11.0",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9",
-    "razorpay": "^2.9.6"
+    "razorpay": "^2.9.6",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/wallstorie/server/routes/shop/addressroutes.js
+++ b/wallstorie/server/routes/shop/addressroutes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 
 const {
   addAddress,
@@ -9,9 +10,15 @@ const {
 
 const router = express.Router();
 
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 router.post("/add", addAddress);
 router.get("/get/:userId", fetchAllAddress);
-router.delete("/delete/:userId/:addressId", deleteAddress);
+router.delete("/delete/:userId/:addressId", limiter, deleteAddress);
 router.put("/update/:userId/:addressId", editAddress);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/7](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/7)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up and apply rate limiting middleware to specific routes or the entire application.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum number of requests per time window).
4. Apply the rate limiter middleware to the routes that require protection, specifically the `deleteAddress` route in this case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
