### PR TITLE
Potential fix for code scanning alert no. 12: Missing rate limiting

### DIFF
--- a/wallstorie/server/package.json
+++ b/wallstorie/server/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.11.0",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9",
-    "razorpay": "^2.9.6"
+    "razorpay": "^2.9.6",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/wallstorie/server/routes/admin/product-routes.js
+++ b/wallstorie/server/routes/admin/product-routes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 
 const {
   handleImageUpload,
@@ -11,10 +12,17 @@ const {
 const { upload } = require("../../helpers/cloudinary");
 
 const router = express.Router();
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 router.post("/upload-image", upload.single("file"), handleImageUpload);
-router.post("/add", addProduct);
-router.put("/edit/:id", editProduct);
-router.delete("/delete/:id", deleteProduct);
+router.post("/add", limiter, addProduct);
+router.put("/edit/:id", limiter, editProduct);
+router.delete("/delete/:id", limiter, deleteProduct);
 router.get("/get", fetchAllProducts);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/12](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/12)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up rate limiting middleware. We will configure the middleware to limit the number of requests to a reasonable number per a defined time window and apply it to the routes that perform database operations.

Specifically, we will:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the routes that perform database operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
