### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/wallstorie/server/package.json
+++ b/wallstorie/server/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^8.11.0",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9",
-    "razorpay": "^2.9.6"
+    "razorpay": "^2.9.6",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/wallstorie/server/routes/admin/product-routes.js
+++ b/wallstorie/server/routes/admin/product-routes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 
 const {
   handleImageUpload,
@@ -11,10 +12,17 @@ const {
 const { upload } = require("../../helpers/cloudinary");
 
 const router = express.Router();
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 router.post("/upload-image", upload.single("file"), handleImageUpload);
 router.post("/add", addProduct);
 router.put("/edit/:id", editProduct);
-router.delete("/delete/:id", deleteProduct);
+router.delete("/delete/:id", limiter, deleteProduct);
 router.get("/get", fetchAllProducts);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/13](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/13)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up a rate limiter and apply it to specific routes or the entire application. In this case, we will apply the rate limiter to the `deleteProduct` route to ensure that it is protected against excessive requests.

We will need to:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the `deleteProduct` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
