### PR TITLE
Potential fix for code scanning alert no. 36: Database query built from user-controlled sources

### DIFF
--- a/wallstorie/server/controllers/admin/ordercontrolleradmin.js
+++ b/wallstorie/server/controllers/admin/ordercontrolleradmin.js
@@ -26,6 +26,10 @@ exports.getOrderDetailsForAdmin = async (req, res) => {
 exports.updateOrderStatus = async (req, res) => {
   try {
     const { status } = req.body;
+    const allowedStatuses = ["pending", "shipped", "delivered", "cancelled"];
+    if (typeof status !== "string" || !allowedStatuses.includes(status)) {
+      return res.status(400).json({ error: "Invalid status value" });
+    }
     const order = await Order.findByIdAndUpdate(
       req.params.id,
       { status },


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/36](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/36)

To fix the problem, we need to ensure that the `status` value is properly validated before it is used in the database query. This can be done by checking that the `status` value is a string and optionally verifying that it matches one of the expected status values.

The best way to fix this without changing existing functionality is to add a validation step before the database query. We will check that `status` is a string and, if necessary, that it matches one of the allowed status values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
