### PR TITLE
Potential fix for code scanning alert no. 39: Database query built from user-controlled sources

### DIFF
--- a/wallstorie/server/controllers/shop/addresscontroller.js
+++ b/wallstorie/server/controllers/shop/addresscontroller.js
@@ -64,6 +64,13 @@ const editAddress = async (req, res) => {
   try {
     const { userId, addressId } = req.params;
     const formData = req.body;
+    const allowedFields = ['address', 'city', 'pincode', 'phone', 'notes'];
+    const sanitizedData = {};
+    allowedFields.forEach(field => {
+      if (formData[field] !== undefined) {
+        sanitizedData[field] = formData[field];
+      }
+    });
 
     if (!userId || !addressId) {
       return res.status(400).json({
@@ -77,7 +84,7 @@ const editAddress = async (req, res) => {
         _id: addressId,
         userId,
       },
-      formData,
+      { $set: sanitizedData },
       { new: true }
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/39](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/39)

To fix the problem, we need to ensure that the user-provided data in `formData` is sanitized before being used in the MongoDB query. One way to achieve this is by using the `$set` operator to update only the fields that are explicitly allowed. This approach ensures that the user input is interpreted as literal values and not as query objects.

1. Define a list of allowed fields that can be updated.
2. Create a new object that only includes these allowed fields from `formData`.
3. Use this sanitized object in the `findOneAndUpdate` query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
