### PR TITLE
Potential fix for code scanning alert no. 45: Database query built from user-controlled sources

### DIFF
--- a/wallstorie/server/controllers/shop/productcontroller.js
+++ b/wallstorie/server/controllers/shop/productcontroller.js
@@ -81,7 +81,7 @@ const getbycategory = async (req, res) => {
     const { category, productType, sortOption, price, space, trends, color } =
       req.query;
 
-    if (!category || !productType) {
+    if (!category || typeof category !== "string" || !productType) {
       return res.status(400).json({
         success: false,
         message: "Category and product type are required",
@@ -89,7 +89,7 @@ const getbycategory = async (req, res) => {
     }
 
     let filterCriteria = {
-      category,
+      category: { $eq: category },
       productType,
     };
 


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/45](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/45)

To fix the problem, we need to ensure that the user-provided `category` parameter is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator to explicitly specify that the value should be treated as a literal. Additionally, we should validate that the `category` parameter is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
