### PR TITLE
Potential fix for code scanning alert no. 60: Database query built from user-controlled sources

### DIFF
--- a/wallstorie/server/controllers/auth/authcontroller.js
+++ b/wallstorie/server/controllers/auth/authcontroller.js
@@ -45,10 +45,10 @@ const loginUser = async (req, res) => {
     let checkUser;
     if (isNaN(identifier)) {
       // If identifier is not a number, treat it as an email
-      checkUser = await User.findOne({ email: identifier });
+      checkUser = await User.findOne({ email: { $eq: identifier } });
     } else {
       // If identifier is a number, treat it as a phone number
-      checkUser = await User.findOne({ phone: identifier });
+      checkUser = await User.findOne({ phone: { $eq: identifier } });
     }
 
     if (!checkUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/60](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/60)

To fix the problem, we need to ensure that the `identifier` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the user input is interpreted as a literal value and not as a query object. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
