### PR TITLE
Potential fix for code scanning alert no. 33: Clear text storage of sensitive information

### DIFF
--- a/wallstorie/server/controllers/auth/authcontroller.js
+++ b/wallstorie/server/controllers/auth/authcontroller.js
@@ -1,6 +1,9 @@
 const bcrypt = require("bcryptjs");
 const User = require("../../models/user");
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
+const ENCRYPTION_KEY = "YOUR_ENCRYPTION_KEY"; // Replace with your actual encryption key
+const IV_LENGTH = 16; // For AES, this is always 16
 
 // Register
 const registerUser = async (req, res) => {
@@ -80,7 +83,9 @@ const loginUser = async (req, res) => {
       { expiresIn: "15m" }
     );
 
-    res.cookie("token", token, { httpOnly: true, secure: false }).json({
+    const encryptedToken = encrypt(token);
+
+    res.cookie("token", encryptedToken, { httpOnly: true, secure: false }).json({
       success: true,
       message: "Logged in successfully",
       user: {
@@ -118,7 +123,8 @@ const authMiddleware = async (req, res, next) => {
   }
 
   try {
-    const decoded = jwt.verify(token, "CLIENT_SECRET_KEY");
+    const decryptedToken = decrypt(token);
+    const decoded = jwt.verify(decryptedToken, "CLIENT_SECRET_KEY");
     req.user = decoded;
     next();
   } catch (error) {
@@ -128,6 +134,24 @@ const authMiddleware = async (req, res, next) => {
     });
   }
 };
+
+function encrypt(text) {
+  let iv = crypto.randomBytes(IV_LENGTH);
+  let cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), iv);
+  let encrypted = cipher.update(text);
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+function decrypt(text) {
+  let textParts = text.split(':');
+  let iv = Buffer.from(textParts.shift(), 'hex');
+  let encryptedText = Buffer.from(textParts.join(':'), 'hex');
+  let decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), iv);
+  let decrypted = decipher.update(encryptedText);
+  decrypted = Buffer.concat([decrypted, decipher.final()]);
+  return decrypted.toString();
+}
 
 module.exports = {
   registerUser,


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/33](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/33)

To fix the problem, we need to encrypt the JWT token before storing it in the cookie. We can use the Node.js `crypto` module to achieve this. The process involves creating a cipher using a secret key, encrypting the token, and then storing the encrypted token in the cookie. When reading the token, we will need to decrypt it using the same secret key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
