### PR TITLE
Potential fix for code scanning alert no. 2: Type confusion through parameter tampering

### DIFF
--- a/wallstorie/server/controllers/shop/cartcontroller.js
+++ b/wallstorie/server/controllers/shop/cartcontroller.js
@@ -31,7 +31,7 @@ const calculatePrice = (
 
 exports.addToCart = async (req, res) => {
   try {
-    const {
+    let {
       userId,
       productId,
       quantity,
@@ -41,6 +41,19 @@ exports.addToCart = async (req, res) => {
       selectedMaterial,
       materialPrice,
     } = req.body;
+
+    // Validate input types
+    if (typeof productId !== 'string' || typeof quantity !== 'number' ||
+        (height && typeof height !== 'number') ||
+        (width && typeof width !== 'number') ||
+        (length && typeof length !== 'number') ||
+        (selectedMaterial && typeof selectedMaterial !== 'string') ||
+        (materialPrice && typeof materialPrice !== 'number')) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid input types",
+      });
+    }
 
     // Validate input
     if (!productId || !quantity) {


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/2](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/2)

To fix the problem, we need to ensure that the parameters extracted from `req.body` are of the expected types. This can be done by adding type checks for each parameter before using them. Specifically, we should check that `productId`, `quantity`, `height`, `width`, `length`, `selectedMaterial`, and `materialPrice` are of the expected types (e.g., `string` or `number`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
