### PR TITLE
Potential fix for code scanning alert no. 80: Missing CSRF middleware

### DIFF
--- a/wallstorie/server/server.js
+++ b/wallstorie/server/server.js
@@ -65,7 +65,7 @@ app.use(
   })
 );
 
-// app.use(lusca.csrf());
+app.use(lusca.csrf());
 
 // Initialize passport
 app.use(passport.initialize());


### PR DESCRIPTION
Potential fix for [https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/80](https://github.com/neekunjchaturvedi/WallStorie/security/code-scanning/80)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package, which is already imported, provides a convenient way to implement CSRF protection. We will enable the CSRF middleware by adding `app.use(lusca.csrf())` after the session middleware setup.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
